### PR TITLE
Made it runnable on Windows too

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@
 
 
 var bcrypt = require('bcrypt');
-var crypt = require('crypt3');
 var crypto = require('crypto');
 
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
  */
 
 
-var bcrypt = require('bcrypt');
+var bcrypt = require('bcryptjs');
 var crypto = require('crypto');
 
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.8",
   "dependencies": {
     "bcrypt": "^0.8.5",
-    "crypt3": "^0.2.0",
     "crypto": "^0.0.3"
   },
   "description": "All password hashing algorithms for Django implemented in javascript for nodejs projects.",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "node-django-hashers",
   "version": "1.0.8",
   "dependencies": {
-    "bcrypt": "^0.8.5",
+    "bcryptjs": "^2.3.0",
     "crypto": "^0.0.3"
   },
   "description": "All password hashing algorithms for Django implemented in javascript for nodejs projects.",


### PR DESCRIPTION
I tried using this module on Windows, but I had problems compiling dependencies.
But crypt3 seemed not actually used, so I removed it.
And I replaced bcrypt with bcryptjs, that's a pure JavaScript drop-in.
This way the module works on Windows too.
I didn't throughfully tested it, so I can't be sure it works in every situation, though...